### PR TITLE
extend test no-warning-errors to check for output_name = 'error' or 'pyerr'

### DIFF
--- a/test_notebooks.py
+++ b/test_notebooks.py
@@ -93,7 +93,9 @@ def test_no_errors_or_warnings_in_output(notebook_filename):
         for cell in notebook.cells:
             if cell.cell_type == "code":
                 for output in cell.outputs:
-                    if (output.get("name") == "stderr") or (output.get("output_type") in ("error", "pyerr")):
+                    if (output.get("name") == "stderr") or (
+                        output.get("output_type") in ("error", "pyerr")
+                    ):
                         if not output["text"].startswith("[Parallel(n_jobs="):
                             raise AssertionError(output["text"])
 


### PR DESCRIPTION
output_name for errors depends on nbformat version (https://ipython.readthedocs.io/en/3.x/notebook/nbformat.html)