### PR TITLE
test: add signature contract tests for hook utils

### DIFF
--- a/tests/test_utils_signature_contract.py
+++ b/tests/test_utils_signature_contract.py
@@ -1,0 +1,34 @@
+# pylint: disable=missing-function-docstring
+
+import inspect
+
+from hooks import check_notebooks as cn
+from hooks import utils
+
+
+def test_open_and_test_notebooks_signature_is_stable():
+    sig = inspect.signature(utils.open_and_test_notebooks)
+    params = list(sig.parameters.keys())
+    assert params == ["argv", "test_functions"]
+
+
+def test_check_notebooks_main_calls_utils_with_matching_keywords(monkeypatch):
+    # Keep this contract explicit: imported utility in the hook exposes the same signature.
+    assert inspect.signature(utils.open_and_test_notebooks) == inspect.signature(
+        cn.open_and_test_notebooks
+    )
+
+    observed = {}
+
+    def fake_open_and_test_notebooks(*, argv, test_functions):
+        observed["argv"] = argv
+        observed["test_functions"] = test_functions
+        return 0
+
+    monkeypatch.setattr(cn, "open_and_test_notebooks", fake_open_and_test_notebooks)
+
+    result = cn.main(argv=["tests/examples/good.ipynb"])
+
+    assert result == 0
+    assert observed["argv"] == ["tests/examples/good.ipynb"]
+    assert observed["test_functions"] == [cn.test_jetbrains_bug_py_66491]


### PR DESCRIPTION
Adds pytest tests to validate that utility functions used by pre-commit hooks have consistent function signatures.

The tests use Python's inspect module to check function parameters and ensure they align with how hooks are expected to call them.

Scope:
- Adds minimal tests for selected hook utility functions
- Focuses only on signature validation (no changes to existing logic)

This helps prevent mismatches between hook implementations and their underlying utility functions.

Let me know if you'd like me to extend coverage to more hooks 👍